### PR TITLE
Fix an exception from "!" in filename

### DIFF
--- a/SrumData/Srum.cs
+++ b/SrumData/Srum.cs
@@ -28,12 +28,32 @@ public class AppInfo
         var tempVal = ExeInfo.Substring(2); //strip !!
         var segs = tempVal.Split('!');
 
+        if (segs.Length < 4)
+        {
+            return;
+        }
+
         ExeInfo = segs[0];
+        int segsLength = segs.Length;
 
-        Unknown = segs[2];
-        ExeInfoDescription = segs[3];
+        // Incase the filename had "!" in it, append everything back up untill the file type extension.
+        for (int i = 1; i < segsLength - 3; i++)
+        {
+            // If the string is empty it means there were several "!", else append "!<originalValue>"
+            if (segs[i].IsNullOrEmpty())
+            {
+                ExeInfo += "!";
+            }
+            else 
+            {
+                ExeInfo += "!" + segs[i];
+            }
+        }
 
-        Timestamp = DateTimeOffset.ParseExact(segs[1], "yyyy/MM/dd:HH:mm:ss", null,
+        Unknown = segs[segsLength - 2];
+        ExeInfoDescription = segs[segsLength - 1];
+
+        Timestamp = DateTimeOffset.ParseExact(segs[segsLength - 3], "yyyy/MM/dd:HH:mm:ss", null,
             DateTimeStyles.AssumeUniversal);
     }
 

--- a/SrumData/Srum.cs
+++ b/SrumData/Srum.cs
@@ -33,7 +33,9 @@ public class AppInfo
             return;
         }
 
-        ExeInfo = segs[0];
+        // Incase the filename starts with "!" return it, otherwise get original value.
+        ExeInfo = segs[0].IsNullOrEmpty() ? "!" : segs[0];
+        
         int segsLength = segs.Length;
 
         // Incase the filename had "!" in it, append everything back up untill the file type extension.


### PR DESCRIPTION
Hi,

while running the program I ran into an exception. The exception is when there is a filename with "!" in it (in my case "osu!.exe"), `tempVal.Split(".exe")` won't work as intended.

What I did is append all of the strings that were caused from additional "!" in a loop. Also I changed that the values `Unknown`, `ExeInfoDescription` and `Timestamp` will take their values starting from the last value.

Hope this helps 🙂