### PR TITLE
Bump all dependencies except for `System.CommandLine`, which is dependent on beta behaviour.

### DIFF
--- a/SrumData/SrumData.csproj
+++ b/SrumData/SrumData.csproj
@@ -22,13 +22,13 @@
         <PackageReference Include="Microsoft.Database.ManagedEsent" Version="3.2.0" />
         <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-        <PackageReference Include="Registry" Version="1.5.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="ServiceStack.Text" Version="8.5.2" />
+        <PackageReference Include="Registry" Version="1.5.1" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="ServiceStack.Text" Version="8.10.0" />
 
         <None Include="../README.md" Pack="true" PackagePath="" />
         <None Include="../icon.png" Pack="true" PackagePath="" />
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/SrumData/SrumData.csproj
+++ b/SrumData/SrumData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net472;net8.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Authors>Eric R. Zimmerman</Authors>
         <Description>Parses SRUM databases on Windows</Description>
@@ -19,15 +19,15 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Database.ManagedEsent" Version="2.0.4" />
+        <PackageReference Include="Microsoft.Database.ManagedEsent" Version="3.2.0" />
         <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
         <PackageReference Include="Registry" Version="1.5.0" />
         <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="ServiceStack.Text" Version="8.5.2" />
 
-        <None Include="../README.md" Pack="true" PackagePath=""/>
-        <None Include="../icon.png" Pack="true" PackagePath=""/>
+        <None Include="../README.md" Pack="true" PackagePath="" />
+        <None Include="../icon.png" Pack="true" PackagePath="" />
         <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SrumECmd/Program.cs
+++ b/SrumECmd/Program.cs
@@ -23,7 +23,7 @@ using Serilog.Events;
 using ServiceStack;
 using SrumData;
 
-#if NET462
+#if NET472
 using Directory = Alphaleonis.Win32.Filesystem.Directory;
 using File = Alphaleonis.Win32.Filesystem.File;
 using Path = Alphaleonis.Win32.Filesystem.Path;
@@ -297,7 +297,7 @@ internal class Program
                 Log.Information("Found SOFTWARE hive '{R}'!", r);
             }
 
-#elif NET462
+#elif NET472
             //kape mode, so find the files
             var ilter = new DirectoryEnumerationFilters();
             ilter.InclusionFilter = fsei =>

--- a/SrumECmd/SrumECmd.csproj
+++ b/SrumECmd/SrumECmd.csproj
@@ -18,15 +18,15 @@
         <PackageReference Include="Costura.Fody" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="CsvHelper" Version="33.0.1" />
-        <PackageReference Include="Exceptionless" Version="6.0.4" />
-        <PackageReference Include="Fody" Version="6.9.1">
+        <PackageReference Include="CsvHelper" Version="33.1.0" />
+        <PackageReference Include="Exceptionless" Version="6.1.0" />
+        <PackageReference Include="Fody" Version="6.9.3">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 
-        <PackageReference Include="ServiceStack.Text" Version="8.5.2" />
+        <PackageReference Include="ServiceStack.Text" Version="8.10.0" />
         
 	<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/SrumECmd/SrumECmd.csproj
+++ b/SrumECmd/SrumECmd.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net462;net6.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <ApplicationIcon>ReportWithChart.ico</ApplicationIcon>
         <Version>1.0.0</Version>

--- a/SrumTest/SrumTest.csproj
+++ b/SrumTest/SrumTest.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
         <PackageReference Include="NFluent" Version="3.1.0" />
-        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I was trying to integrate this project into a .NET Framework package, but the older `Microsoft.Database.ManagedEsent` package of 2.0.4 targeting netstandard2.0 wasn't overly suitable.

The team have released 3.2.0, which properly targets net472 as well as net8.0 and higher. I've updated the NuGet package to this and fixed up the preprocessor guard clauses also.

I also updated every other package in a separate commit while I was there. I could not update `System.CommandLine` to the final 2.0.0 release due to https://github.com/dotnet/command-line-api/issues/2571; a decision by a project team member would have to be made there.